### PR TITLE
Change inverter and logger variable to str

### DIFF
--- a/solarman_mqtt/config.yaml
+++ b/solarman_mqtt/config.yaml
@@ -41,8 +41,8 @@ schema:
   solarman_secret: str
   solarman_name: str
   solarman_station: int
-  solarman_inverter: int
-  solarman_logger: int
+  solarman_inverter: str
+  solarman_logger: str
   mqtt_broker: str
   mqtt_port: int
   mqtt_topic: str


### PR DESCRIPTION
Change solarman_inverter and solarman_logger to accept string inputs instead of being limited to integer as there are some inverters that uses letters on their SN (ex. SA3N5xxxxxxx)